### PR TITLE
Handle XMPP error events

### DIFF
--- a/lib/harmonyclient.js
+++ b/lib/harmonyclient.js
@@ -48,6 +48,9 @@ function HarmonyClient (xmppClient) {
   }
 
   xmppClient.on('stanza', handleStanza.bind(self))
+  xmppClient.on('error', function(error){
+    console.log("XMPP Error: " + error.message);
+  })
   EventEmitter.call(this)
 }
 util.inherits(HarmonyClient, EventEmitter)

--- a/lib/harmonyclient.js
+++ b/lib/harmonyclient.js
@@ -49,7 +49,7 @@ function HarmonyClient (xmppClient) {
 
   xmppClient.on('stanza', handleStanza.bind(self))
   xmppClient.on('error', function (error) {
-    console.log('XMPP Error: ' + error.message)
+    debug('XMPP Error: ' + error.message)
   })
   EventEmitter.call(this)
 }

--- a/lib/harmonyclient.js
+++ b/lib/harmonyclient.js
@@ -48,8 +48,8 @@ function HarmonyClient (xmppClient) {
   }
 
   xmppClient.on('stanza', handleStanza.bind(self))
-  xmppClient.on('error', function(error){
-    console.log("XMPP Error: " + error.message);
+  xmppClient.on('error', function (error) {
+    console.log('XMPP Error: ' + error.message);
   })
   EventEmitter.call(this)
 }

--- a/lib/harmonyclient.js
+++ b/lib/harmonyclient.js
@@ -49,7 +49,7 @@ function HarmonyClient (xmppClient) {
 
   xmppClient.on('stanza', handleStanza.bind(self))
   xmppClient.on('error', function (error) {
-    console.log('XMPP Error: ' + error.message);
+    console.log('XMPP Error: ' + error.message)
   })
   EventEmitter.call(this)
 }


### PR DESCRIPTION
XMPP error events are not currently being handled. When errors aren't handled, they're thrown. Unfortunately for projects that use this lib, when this happens, we can't catch these thrown errors.

I've personally been struggling with this in my [harmony-api](https://github.com/maddox/harmony-api) project.

I know this handling is super naive, and the error should probably be returned instead, but my experience with this stuff is pretty small. I figure that this pull could at least get a conversation going.
