### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "harmonyhubjs-client",
+  "version": "1.1.8",
   "description": "harmonyhubjs-client is a Node.JS library which allows you to interact with your Logitech Harmony Hub.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
There's no version number listed in the `package.json`. This makes installing the package directly from GitHub or any git URL impossible with NPM.