### PR TITLE
Add a cache for "config"

### DIFF
--- a/lib/harmonyclient.js
+++ b/lib/harmonyclient.js
@@ -17,6 +17,7 @@ function HarmonyClient (xmppClient) {
 
   self._xmppClient = xmppClient
   self._responseHandlerQueue = []
+  self._availableCommandsCache = null
 
   function handleStanza (stanza) {
     debug('handleStanza(' + stanza.toString() + ')')
@@ -152,8 +153,17 @@ function isOff () {
 function getAvailableCommands () {
   debug('retrieve available commands')
 
+  if (this._availableCommandsCache) {
+    debug('using cached config')
+    var deferred = Q.defer()
+    deferred.resolve(this._availableCommandsCache)
+    return deferred.promise
+  }
+
+  var self = this
   return this.request('config', undefined, 'json')
     .then(function (response) {
+      self._availableCommandsCache = response
       return response
     })
 }


### PR DESCRIPTION
Because `getAvailableCommands()` is used as the basis for many other
actions, and the payload is so gigantic, plus the fact that it does
not change very frequently, it makes sense to keep that response
cached.

The only way this would become out of sync is if you make changes to
the harmony setup (activities and devices).

To improve on this, it might make sense to see if we can detect when the hub needs a sync, and invalidate the cache then.  Or we can add a cache expiration time.

For most clients, the cache isn't needed. This is only useful for a client that keeps the connection open for a long time -- like a REST web service that dispatches commands to Harmony.