### PR TITLE
Fix disconnect issue

### DIFF
--- a/lib/login/hub.js
+++ b/lib/login/hub.js
@@ -28,7 +28,8 @@ function getIdentity (hubhost, hubport) {
     password: 'guest',
     host: hubhost,
     port: hubport,
-    disallowTLS: true
+    disallowTLS: true,
+    reconnect: true
   })
 
   xmppClient.on('online', function () {


### PR DESCRIPTION
Set reconnect to true to keep-alive

There have been a number of threads (including in dependencies) raising
an issue where this client stops working a certain period of time after connecting.

The issue stems from the underlying `xmppClient` client. It will emit an 'offline'
event in the case of losing connection. This could be listened for and acted on
accordingly. However, there is a simpler solution:

The `xmppClient` client has a 'reconnect' option during creation. When set to
`true`, it will auto-reconnect when it goes offline, and no further action is needed.