### PR TITLE
Fix disconnect issue (MAX_CLIENTS=6)

### DIFF
--- a/lib/login/hub.js
+++ b/lib/login/hub.js
@@ -28,7 +28,8 @@ function getIdentity (hubhost, hubport) {
     password: 'guest',
     host: hubhost,
     port: hubport,
-    disallowTLS: true
+    disallowTLS: true,
+    reconnect: true
   })
 
   xmppClient.on('online', function () {
@@ -45,8 +46,9 @@ function getIdentity (hubhost, hubport) {
   })
 
   xmppClient.on('error', function (e) {
-    debug('XMPP client error')
-    console.log('errorhub', e)
+    debug('XMPP client error', e)
+    xmppClient.end()
+    deferred.reject(e)
   })
 
   xmppClient.on('stanza', function (stanza) {
@@ -98,6 +100,12 @@ function loginWithIdentity (identity, hubhost, hubport) {
     host: hubhost,
     port: hubport,
     disallowTLS: true
+  })
+
+  xmppClient.on('error', function (e) {
+    debug('XMPP login error', e)
+    xmppClient.end()
+    deferred.reject(e)
   })
 
   xmppClient.once('online', function () {


### PR DESCRIPTION
- Add error handler to the XMPP 'login' client
- Reject promises in both error handlers
- Enable auto-reconnection